### PR TITLE
Changed presentation in display of Temp and Hum.

### DIFF
--- a/operame.ino
+++ b/operame.ino
@@ -183,7 +183,7 @@ void display_ppm_t_h(int ppm, float t, float h) {
         std::swap(fg, bg);
     }
 
-    display_3(String(ppm), String(t), String(h), fg, bg);
+    display_3(String(ppm), String(int(t)) + String("`C"), String(int(h)) + String("%"), fg, bg);
 }
 
 void calibrate() {


### PR DESCRIPTION
Dit display geeft de temperatuur en luchtvochtigheid mooier weer dan het origineel. Vanwege de onnauwkeurigheid van de DHT22 volstaat het ook om geen decimalen weer te geven. Aan temperatuur is °C toegevoegd en aan de luchtvochtigheid %.